### PR TITLE
fixing regexp for extension validation

### DIFF
--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -53,7 +53,7 @@ class StorageBase {
 
         // poor extension validation
         // .1 is not a valid extension
-        if (!ext.match(/.\d/)) {
+        if (!ext.match(/\.\d+$/)) {
             name = this.getSanitizedFileName(path.basename(image.name, ext));
             return this.generateUnique(targetDir, name, ext, 0);
         } else {


### PR DESCRIPTION
Regexp for extension validation was meant to match ".1", ".23" and alike but it does match ".mp3", ".mp4" and any extension with at least a digit. This change is a fix for it.