### PR TITLE
Remove moment.js dependency

### DIFF
--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -1,5 +1,4 @@
-const moment = require('moment'),
-    path = require('path');
+const path = require('path');
 
 class StorageBase {
     constructor() {
@@ -10,9 +9,9 @@ class StorageBase {
     }
 
     getTargetDir(baseDir) {
-        const date = moment(),
-            month = date.format('MM'),
-            year = date.format('YYYY');
+        const date = new Date(),
+            month = date.toLocaleString('default', { month: '2-digit' }),
+            year = date.toLocaleString('default', { year: 'numeric' });
 
         if (baseDir) {
             return path.join(baseDir, year, month);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "main": "./BaseStorage",
   "dependencies": {
-    "moment": "2.27.0"
   },
   "engine": {
     "node": "^12.22.1 || ^14.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,11 +343,6 @@ mocha@9.1.2:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-moment@2.27.0:
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
-  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"


### PR DESCRIPTION
This pull request removes a 4.21 MB dependency that exists for the mere sake of producing date in a `2021/09` format.