### PR TITLE
🔒 Made filename generation more secure, performant and resilient to filesystems' limits

### DIFF
--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -2,8 +2,8 @@ const moment = require('moment');
 const path = require('path');
 const crypto = require('crypto');
 
-// UNIX filesystems usually have a 255 bytes length limit for filenames
-// We keep an additional 2 bytes buffer for an eventual suffix in the filename (e.g. "_o" for original files after transformation)
+// Most UNIX filesystems have a 255 bytes limit for the filename length
+// We keep 2 additional bytes, to make space for a file suffix (e.g. "_o" for original files after transformation)
 const MAX_FILENAME_BYTES = 253;
 
 class StorageBase {
@@ -80,7 +80,7 @@ class StorageBase {
         return ext;
     }
 
-    /** Generate a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
+    /** Generates a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
      *  Uses 8 random bytes -> 8 * 8 = 64 bits of entropy -> 2^64 possible combinations (18 quintillion, i.e. 18 followed by 18 zeros)
      *
      *  @returns {String}
@@ -89,7 +89,7 @@ class StorageBase {
         return crypto.randomBytes(8).toString('hex');
     }
 
-    /** Generate a filename with the following format: my-file-1a2b3c4d5e6f_o.png, with a filename length under MAX_FILENAME_LENGTH
+    /** Generates a filename with the following format: my-file-1a2b3c4d5e6f7890.png, with a filename length under MAX_FILENAME_LENGTH
      *
      * @param {String} stem -- stem of the file without path nor extension, e.g. my-file. If needed, this will be truncated, so that the filename is under MAX_FILENAME_BYTES
      * @param {String} hash -- a secured hash to append the file, after the stem of the file, e.g. 1a2b3c4d5e6f
@@ -115,13 +115,14 @@ class StorageBase {
         return filename;
     }
 
-    /** Deprecated: use getUniqueSecureFilePath instead
+    /**
+     * [Deprecated] Returns a unique file path for a given file and target directory
+     *
      * @param {Object} file
      * @param {String} file.name
      * @param {String} targetDir
-     *
-     * @returns {Promise<String>} unique file path
-     * @deprecated
+     * @returns {Promise<String>}
+     * @deprecated use getUniqueSecureFilePath instead
      */
     getUniqueFileName(file, targetDir) {
         var ext = path.extname(file.name), name;
@@ -138,13 +139,13 @@ class StorageBase {
     }
 
     /**
-     * Deprecated alongside getUniqueFileName: use getUniqueSecureFilePath instead
+     * [Deprecated] Generates a unique file path using a numbering system, e.g. image.png, image-1.png, image-2.png, etc.
      * @param {String} dir
      * @param {String} name
      * @param {String} ext
      * @param {Number} i index
      * @returns {Promise<String>}
-     * @deprecated
+     * @deprecated use getUniqueSecureFilePath instead
      */
     generateUnique(dir, name, ext, i) {
         let filename;

--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -1,5 +1,12 @@
-const moment = require('moment'),
-    path = require('path');
+const moment = require('moment');
+const path = require('path');
+const crypto = require('crypto');
+
+// Filesystems usually have a filename length limit -- 255 bytes is the standard limit on Unix-based systems
+const MAX_FILENAME_BYTES = 255;
+
+// When an uploaded file is transformed, we keep the original file with the '_o suffix
+const ORIGINAL_SUFFIX = '_o';
 
 class StorageBase {
     constructor() {
@@ -21,63 +28,123 @@ class StorageBase {
         return path.join(year, month);
     }
 
-    /**
-     * 
-     * @param {String} dir 
-     * @param {String} name 
-     * @param {String} ext
-     * @param {Number} i index
+    /** Generate a filename with the following format: my-file-1a2b3c4d5e6f_o.png, with a filename length under MAX_FILENAME_LENGTH
+     *
+     * @param {String} stem -- stem of the file without path nor extension, e.g. my-file. If needed, this will be truncated, so that the filename is under MAX_FILENAME_BYTES
+     * @param {String} hash -- a secured hash to append the file, after the stem of the file, e.g. 1a2b3c4d5e6f
+     * @param {String} ext -- the extension of the file, e.g. ".png"
+     * @param {String} suffix -- optional, suffix to keep at the end of the stem, e.g. "_o"
+     * @returns {String}
+     */
+    generateFilename({stem, hash, suffix = '', ext = ''}) {
+        const encoder = new TextEncoder();
+        let filename = `${stem}-${hash}${suffix}${ext}`;
+
+        const fileNameBytes = encoder.encode(filename);
+
+        // If the filename has more bytes than the maximum allowed, truncate the stem
+        if (fileNameBytes.length > MAX_FILENAME_BYTES) {
+            const stemBytes = encoder.encode(stem);
+            const bytesToRemove = fileNameBytes.length - MAX_FILENAME_BYTES;
+            const newStemBytes = stemBytes.slice(0, -bytesToRemove);
+
+            const decoder = new TextDecoder();
+            filename = `${decoder.decode(newStemBytes)}-${hash}${suffix}${ext}`;
+        }
+
+        return filename;
+    }
+
+    /** Generate a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
+     *  Uses 8 random bytes -> 8 * 8 = 64 bits of entropy -> 2^64 possible combinations (18 quintillion, i.e. 18 followed by 18 zeros)
+     *
+     *  @returns {String}
+     */
+    generateSecureHash() {
+        return crypto.randomBytes(8).toString('hex');
+    }
+
+    /** Generate a unique and secure filename
+     *
+     * @param {String} stem -- stem of the file without path nor extension, e.g. my-file
+     * @param {String} ext -- the extension of the file, e.g. ".png"
+     * @param {String} suffix -- optional, suffix to keep at the end of the stem, e.g. "_o"
      * @returns {Promise<String>}
      */
-    generateUnique(dir, name, ext, i) {
-        let filename,
-            append = '';
+    generateUniqueFilename({stem, suffix, ext}) {
+        const hash = this.generateSecureHash();
 
-        if (i) {
-            append = '-' + i;
-        }
-
-        if (ext) {
-            filename = name + append + ext;
-        } else {
-            filename = name + append;
-        }
-
-        return this.exists(filename, dir).then((exists) => {
-            if (exists) {
-                i = i + 1;
-                return this.generateUnique(dir, name, ext, i);
-            } else {
-                return path.join(dir, filename);
-            }
-        });
+        return this.generateFilename({stem, hash, suffix, ext});
     }
 
     /**
-     * @param {Object} file
-     * @param {String} file.name
-     * @param {String} targetDir
-     * 
-     * @returns {Promise<String>} unique file path
+     * @param {Object} options
+     * @param {Object} options.file
+     * @param {String} options.file.name -- the name of the file
+     * @param {String} options.file.suffix -- the suffix to use for the file, e.g. "_o"
+     * @param {String} options.targetDir -- the target directory to save the file in
+     * @returns {string} Generated unique file pathname
      */
-    getUniqueFileName(file, targetDir) {
-        var ext = path.extname(file.name), name;
+    getUniquePathname({
+        file: {
+            name: fileName,
+            suffix: fileSuffix = ORIGINAL_SUFFIX
+        },
+        targetDir
+    }) {
+        const basename = this.sanitizeBasename(path.basename(fileName));
+        const ext = this.getFileExtension(basename);
+        const suffix = this.getSuffix(basename, ext, fileSuffix);
+        const stem = path.basename(basename, suffix + ext);
 
-        // poor extension validation
-        // .1 or .342 is not a valid extension, .mp4 is though!
-        if (!ext.match(/\.\d+$/)) {
-            name = this.getSanitizedFileName(path.basename(file.name, ext));
-            return this.generateUnique(targetDir, name, ext, 0);
-        } else {
-            name = this.getSanitizedFileName(path.basename(file.name));
-            return this.generateUnique(targetDir, name, null, 0);
-        }
+        const filename = this.generateUniqueFilename({stem, suffix, ext});
+
+        return path.join(targetDir, filename);
     }
 
-    getSanitizedFileName(fileName) {
-        // below only matches ascii characters, @, and .
-        // unicode filenames like город.zip would therefore resolve to ----.zip
-        return fileName.replace(/[^\w@.]/gi, '-');
+    /** Extracts the file extension from the filename, if it is a valid extension
+     *
+     * @param {string} fileName
+     * @returns {string}
+     */
+    getFileExtension(filename) {
+        const ext = path.extname(filename);
+
+        // If the extension is not a valid extension, return an empty string
+        if (!ext.match(/(\.[a-z0-9]{2,10})+$/i)) {
+            return '';
+        }
+
+        return ext;
+    }
+
+    /** Extracts the given from the basename, if it exists
+     *
+     * @param {String} filename
+     * @param {String} ext
+     * @param {String} suffix
+     * @returns {String}
+     */
+    getSuffix(filename, ext, suffix) {
+        const stem = path.basename(filename, ext);
+
+        // If the stem does not end with the suffix, return an empty string
+        if (!stem.endsWith(suffix)) {
+            return '';
+        }
+
+        return suffix;
+    }
+
+    /** Sanitizes the basename of the file, to accept only ASCII characters, '@', and '.'
+     *  Replaces other characters with dashes.
+     *  Example: город.zip is replaced with ----.zip
+     *
+     * @param {String} basename
+     * @returns {String}
+     */
+    sanitizeBasename(basename) {
+        return basename.replace(/[^\w@.]/gi, '-');
     }
 }
 

--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -31,29 +31,24 @@ class StorageBase {
     /**
      * Generates a unique and secure file path for a given file and target directory
      *
-     * @param {Object} options
-     * @param {Object} options.file
-     * @param {String} options.file.name -- the name of the file
-     * @param {String} options.file.suffix -- the suffix to use for the file, e.g. "_o"
-     * @param {String} options.targetDir -- the target directory to save the file in
+     * @param {Object} file
+     * @param {String} file.name -- the name of the file
+     * @param {String} file.suffix -- the suffix to use for the file, e.g. "_o"
+     * @param {String} targetDir -- the target directory to save the file in
      * @returns {string}
      */
-    getUniqueSecureFilePath({
-        file: {
-            name: fileName,
-            suffix: fileSuffix = ORIGINAL_SUFFIX
-        },
-        targetDir
-    }) {
-        const sanitizedFileName = this.sanitizeFileName(path.basename(fileName));
+    getUniqueSecureFilePath(file = {name: '', suffix: ''}, targetDir) {
+        const originalFileName = path.basename(file.name);
+        const sanitizedFileName = this.sanitizeFileName(originalFileName);
+
         const ext = this.getFileExtension(sanitizedFileName);
-        const suffix = this.getSuffix({fileName: sanitizedFileName, ext, suffix: fileSuffix});
+        const suffix = this.getSuffix({fileName: sanitizedFileName, ext, suffix: file.suffix || ORIGINAL_SUFFIX});
         const stem = path.basename(sanitizedFileName, suffix + ext);
         const hash = this.generateSecureHash();
 
-        const filename = this.generateFileName({stem, hash, suffix, ext});
+        const newFileName = this.generateFileName({stem, hash, suffix, ext});
 
-        return path.join(targetDir, filename);
+        return path.join(targetDir, newFileName);
     }
 
     /** Sanitizes the file name, to accept only ASCII characters, '@', and '.'

--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -146,6 +146,61 @@ class StorageBase {
     sanitizeBasename(basename) {
         return basename.replace(/[^\w@.]/gi, '-');
     }
+
+    /** Deprecated: use getUniquePathname instead
+     * @param {Object} file
+     * @param {String} file.name
+     * @param {String} targetDir
+     *
+     * @returns {Promise<String>} unique file path
+     * @deprecated
+     */
+    getUniqueFileName(file, targetDir) {
+        var ext = path.extname(file.name), name;
+
+        // poor extension validation
+        // .1 or .342 is not a valid extension, .mp4 is though!
+        if (!ext.match(/\.\d+$/)) {
+            name = this.sanitizeBasename(path.basename(file.name, ext));
+            return this.generateUnique(targetDir, name, ext, 0);
+        } else {
+            name = this.sanitizeBasename(path.basename(file.name));
+            return this.generateUnique(targetDir, name, null, 0);
+        }
+    }
+
+    /**
+     * Deprecated
+     * @param {String} dir
+     * @param {String} name
+     * @param {String} ext
+     * @param {Number} i index
+     * @returns {Promise<String>}
+     * @deprecated
+     */
+    generateUnique(dir, name, ext, i) {
+        let filename,
+            append = '';
+
+        if (i) {
+            append = '-' + i;
+        }
+
+        if (ext) {
+            filename = name + append + ext;
+        } else {
+            filename = name + append;
+        }
+
+        return this.exists(filename, dir).then((exists) => {
+            if (exists) {
+                i = i + 1;
+                return this.generateUnique(dir, name, ext, i);
+            } else {
+                return path.join(dir, filename);
+            }
+        });
+    }
 }
 
 module.exports = StorageBase;

--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 // Filesystems usually have a filename length limit -- 255 bytes is the standard limit on Unix-based systems
 const MAX_FILENAME_BYTES = 255;
 
-// When an uploaded file is transformed, we keep the original file with the '_o suffix
+// When an uploaded file is transformed, the original file is stored with the suffix '_o'
 const ORIGINAL_SUFFIX = '_o';
 
 class StorageBase {
@@ -17,9 +17,9 @@ class StorageBase {
     }
 
     getTargetDir(baseDir) {
-        const date = moment(),
-            month = date.format('MM'),
-            year = date.format('YYYY');
+        const date = moment();
+        const month = date.format('MM');
+        const year = date.format('YYYY');
 
         if (baseDir) {
             return path.join(baseDir, year, month);
@@ -28,78 +28,43 @@ class StorageBase {
         return path.join(year, month);
     }
 
-    /** Generate a filename with the following format: my-file-1a2b3c4d5e6f_o.png, with a filename length under MAX_FILENAME_LENGTH
-     *
-     * @param {String} stem -- stem of the file without path nor extension, e.g. my-file. If needed, this will be truncated, so that the filename is under MAX_FILENAME_BYTES
-     * @param {String} hash -- a secured hash to append the file, after the stem of the file, e.g. 1a2b3c4d5e6f
-     * @param {String} ext -- the extension of the file, e.g. ".png"
-     * @param {String} suffix -- optional, suffix to keep at the end of the stem, e.g. "_o"
-     * @returns {String}
-     */
-    generateFilename({stem, hash, suffix = '', ext = ''}) {
-        const encoder = new TextEncoder();
-        let filename = `${stem}-${hash}${suffix}${ext}`;
-
-        const fileNameBytes = encoder.encode(filename);
-
-        // If the filename has more bytes than the maximum allowed, truncate the stem
-        if (fileNameBytes.length > MAX_FILENAME_BYTES) {
-            const stemBytes = encoder.encode(stem);
-            const bytesToRemove = fileNameBytes.length - MAX_FILENAME_BYTES;
-            const newStemBytes = stemBytes.slice(0, -bytesToRemove);
-
-            const decoder = new TextDecoder();
-            filename = `${decoder.decode(newStemBytes)}-${hash}${suffix}${ext}`;
-        }
-
-        return filename;
-    }
-
-    /** Generate a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
-     *  Uses 8 random bytes -> 8 * 8 = 64 bits of entropy -> 2^64 possible combinations (18 quintillion, i.e. 18 followed by 18 zeros)
-     *
-     *  @returns {String}
-     */
-    generateSecureHash() {
-        return crypto.randomBytes(8).toString('hex');
-    }
-
-    /** Generate a unique and secure filename
-     *
-     * @param {String} stem -- stem of the file without path nor extension, e.g. my-file
-     * @param {String} ext -- the extension of the file, e.g. ".png"
-     * @param {String} suffix -- optional, suffix to keep at the end of the stem, e.g. "_o"
-     * @returns {Promise<String>}
-     */
-    generateUniqueFilename({stem, suffix, ext}) {
-        const hash = this.generateSecureHash();
-
-        return this.generateFilename({stem, hash, suffix, ext});
-    }
-
     /**
+     * Generates a unique and secure file path for a given file and target directory
+     *
      * @param {Object} options
      * @param {Object} options.file
      * @param {String} options.file.name -- the name of the file
      * @param {String} options.file.suffix -- the suffix to use for the file, e.g. "_o"
      * @param {String} options.targetDir -- the target directory to save the file in
-     * @returns {string} Generated unique file pathname
+     * @returns {string}
      */
-    getUniquePathname({
+    getUniqueSecureFilePath({
         file: {
             name: fileName,
             suffix: fileSuffix = ORIGINAL_SUFFIX
         },
         targetDir
     }) {
-        const basename = this.sanitizeBasename(path.basename(fileName));
-        const ext = this.getFileExtension(basename);
-        const suffix = this.getSuffix(basename, ext, fileSuffix);
-        const stem = path.basename(basename, suffix + ext);
+        const sanitizedFileName = this.sanitizeFileName(path.basename(fileName));
+        const ext = this.getFileExtension(sanitizedFileName);
+        const suffix = this.getSuffix({fileName: sanitizedFileName, ext, suffix: fileSuffix});
+        const stem = path.basename(sanitizedFileName, suffix + ext);
+        const hash = this.generateSecureHash();
 
-        const filename = this.generateUniqueFilename({stem, suffix, ext});
+        const filename = this.generateFileName({stem, hash, suffix, ext});
 
         return path.join(targetDir, filename);
+    }
+
+    /** Sanitizes the file name, to accept only ASCII characters, '@', and '.'
+     *  Replaces other characters with dashes.
+     *  Example: город.zip is replaced with ----.zip
+     *
+     * @param {String} fileName
+     * @returns {String}
+     */
+    sanitizeFileName(fileName) {
+        return fileName.replace(/[^\w@.]/gi, '-');
     }
 
     /** Extracts the file extension from the filename, if it is a valid extension
@@ -118,15 +83,16 @@ class StorageBase {
         return ext;
     }
 
-    /** Extracts the given from the basename, if it exists
+    /** Extracts the given suffix from the file name, if it exists
      *
-     * @param {String} filename
-     * @param {String} ext
-     * @param {String} suffix
+     * @param {Object} options
+     * @param {String} options.fileName
+     * @param {String} options.ext
+     * @param {String} options.suffix
      * @returns {String}
      */
-    getSuffix(filename, ext, suffix) {
-        const stem = path.basename(filename, ext);
+    getSuffix({fileName, ext = '', suffix = ''}) {
+        const stem = path.basename(fileName, ext);
 
         // If the stem does not end with the suffix, return an empty string
         if (!stem.endsWith(suffix)) {
@@ -136,18 +102,43 @@ class StorageBase {
         return suffix;
     }
 
-    /** Sanitizes the basename of the file, to accept only ASCII characters, '@', and '.'
-     *  Replaces other characters with dashes.
-     *  Example: город.zip is replaced with ----.zip
+    /** Generate a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
+     *  Uses 8 random bytes -> 8 * 8 = 64 bits of entropy -> 2^64 possible combinations (18 quintillion, i.e. 18 followed by 18 zeros)
      *
-     * @param {String} basename
-     * @returns {String}
+     *  @returns {String}
      */
-    sanitizeBasename(basename) {
-        return basename.replace(/[^\w@.]/gi, '-');
+    generateSecureHash() {
+        return crypto.randomBytes(8).toString('hex');
     }
 
-    /** Deprecated: use getUniquePathname instead
+    /** Generate a filename with the following format: my-file-1a2b3c4d5e6f_o.png, with a filename length under MAX_FILENAME_LENGTH
+     *
+     * @param {String} stem -- stem of the file without path nor extension, e.g. my-file. If needed, this will be truncated, so that the filename is under MAX_FILENAME_BYTES
+     * @param {String} hash -- a secured hash to append the file, after the stem of the file, e.g. 1a2b3c4d5e6f
+     * @param {String} ext -- the extension of the file, e.g. ".png"
+     * @param {String} suffix -- optional, suffix to keep at the end of the stem, e.g. "_o"
+     * @returns {String}
+     */
+    generateFileName({stem, hash, suffix = '', ext = ''}) {
+        const encoder = new TextEncoder();
+        let filename = `${stem}-${hash}${suffix}${ext}`;
+
+        const fileNameBytes = encoder.encode(filename);
+
+        // If the filename has more bytes than the maximum allowed, truncate the stem
+        if (fileNameBytes.length > MAX_FILENAME_BYTES) {
+            const stemBytes = encoder.encode(stem);
+            const bytesToRemove = fileNameBytes.length - MAX_FILENAME_BYTES;
+            const newStemBytes = stemBytes.slice(0, -bytesToRemove);
+
+            const decoder = new TextDecoder();
+            filename = `${decoder.decode(newStemBytes)}-${hash}${suffix}${ext}`;
+        }
+
+        return filename;
+    }
+
+    /** Deprecated: use getUniqueSecureFilePath instead
      * @param {Object} file
      * @param {String} file.name
      * @param {String} targetDir
@@ -161,16 +152,16 @@ class StorageBase {
         // poor extension validation
         // .1 or .342 is not a valid extension, .mp4 is though!
         if (!ext.match(/\.\d+$/)) {
-            name = this.sanitizeBasename(path.basename(file.name, ext));
+            name = this.sanitizeFileName(path.basename(file.name, ext));
             return this.generateUnique(targetDir, name, ext, 0);
         } else {
-            name = this.sanitizeBasename(path.basename(file.name));
+            name = this.sanitizeFileName(path.basename(file.name));
             return this.generateUnique(targetDir, name, null, 0);
         }
     }
 
     /**
-     * Deprecated
+     * Deprecated alongside getUniqueFileName: use getUniqueSecureFilePath instead
      * @param {String} dir
      * @param {String} name
      * @param {String} ext
@@ -179,8 +170,8 @@ class StorageBase {
      * @deprecated
      */
     generateUnique(dir, name, ext, i) {
-        let filename,
-            append = '';
+        let filename;
+        let append = '';
 
         if (i) {
             append = '-' + i;

--- a/BaseStorage.js
+++ b/BaseStorage.js
@@ -44,18 +44,19 @@ class StorageBase {
         const originalFileName = path.basename(file.name);
         const sanitizedFileName = this.sanitizeFileName(originalFileName);
 
-        const ext = this.getFileExtension(sanitizedFileName);
-        const stem = path.basename(sanitizedFileName, ext);
-        const hash = this.generateSecureHash();
+        const ext = this.getFileExtension(sanitizedFileName); // e.g. ".png"
+        const name = path.basename(sanitizedFileName, ext); // e.g. my-file
+        const hash = this.generateSecureHash(); // e.g. 1a2b3c4d5e6f7890
 
-        const newFileName = this.generateFileName({stem, hash, ext});
+        const newFileName = this.generateFileName({name, hash, ext}); // e.g. my-file-1a2b3c4d5e6f7890.png
 
         return path.join(targetDir, newFileName);
     }
 
-    /** Sanitizes the file name, to accept only ASCII characters, '@', and '.'
-     *  Replaces other characters with dashes.
-     *  Example: город.zip is replaced with ----.zip
+    /**
+     * Sanitizes the file name, to accept only ASCII characters, '@', and '.'
+     * Replaces other characters with dashes.
+     * Example: город.zip is replaced with ----.zip
      *
      * @param {String} fileName
      * @returns {String}
@@ -64,7 +65,8 @@ class StorageBase {
         return fileName.replace(/[^\w@.]/gi, '-');
     }
 
-    /** Extracts the file extension from the filename, if it is a valid extension
+    /**
+     * Extracts the file extension from the filename, if it is a valid extension
      *
      * @param {string} fileName
      * @returns {string}
@@ -80,36 +82,38 @@ class StorageBase {
         return ext;
     }
 
-    /** Generates a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
-     *  Uses 8 random bytes -> 8 * 8 = 64 bits of entropy -> 2^64 possible combinations (18 quintillion, i.e. 18 followed by 18 zeros)
+    /**
+     * Generates a secure hash for the filename, to make it very unlikely to be guessed and very likely to be unique
+     * Uses 8 random bytes -> 8 * 8 = 64 bits of entropy -> 2^64 possible combinations (18 quintillion, i.e. 18 followed by 18 zeros)
      *
-     *  @returns {String}
+     * @returns {string}
      */
     generateSecureHash() {
         return crypto.randomBytes(8).toString('hex');
     }
 
-    /** Generates a filename with the following format: my-file-1a2b3c4d5e6f7890.png, with a filename length under MAX_FILENAME_LENGTH
+        /**
+     * Generates a filename with the following format: my-file-1a2b3c4d5e6f7890.png, with a filename length under MAX_FILENAME_LENGTH
      *
-     * @param {String} stem -- stem of the file without path nor extension, e.g. my-file. If needed, this will be truncated, so that the filename is under MAX_FILENAME_BYTES
+     * @param {String} name -- name of the file without extension, e.g. my-file. If needed, this will be truncated, so that the filename is under MAX_FILENAME_BYTES
      * @param {String} hash -- a secured hash to append the file, after the stem of the file, e.g. 1a2b3c4d5e6f
      * @param {String} ext -- the extension of the file, e.g. ".png"
      * @returns {String}
      */
-    generateFileName({stem, hash, ext = ''}) {
+    generateFileName({name, hash, ext = ''}) {
         const encoder = new TextEncoder();
-        let filename = `${stem}-${hash}${ext}`;
+        let filename = `${name}-${hash}${ext}`;
 
         const fileNameBytes = encoder.encode(filename);
 
-        // If the filename has more bytes than the maximum allowed, truncate the stem
+        // If the filename has more bytes than the maximum allowed, truncate the name
         if (fileNameBytes.length > MAX_FILENAME_BYTES) {
-            const stemBytes = encoder.encode(stem);
+            const nameBytes = encoder.encode(name);
             const bytesToRemove = fileNameBytes.length - MAX_FILENAME_BYTES;
-            const newStemBytes = stemBytes.slice(0, -bytesToRemove);
+            const truncatedNameBytes = nameBytes.slice(0, -bytesToRemove);
 
             const decoder = new TextDecoder();
-            filename = `${decoder.decode(newStemBytes)}-${hash}${ext}`;
+            filename = `${decoder.decode(truncatedNameBytes)}-${hash}${ext}`;
         }
 
         return filename;
@@ -119,12 +123,14 @@ class StorageBase {
      * [Deprecated] Returns a unique file path for a given file and target directory
      *
      * @param {Object} file
-     * @param {String} file.name
-     * @param {String} targetDir
-     * @returns {Promise<String>}
+     * @param {string} file.name
+     * @param {string} targetDir
+     * @returns {Promise<string>}
      * @deprecated use getUniqueSecureFilePath instead
      */
     getUniqueFileName(file, targetDir) {
+        logging.warn('getUniqueFileName is deprecated. Use getUniqueSecureFilePath instead.');
+
         var ext = path.extname(file.name), name;
 
         // poor extension validation

--- a/test/BaseStorage.test.js
+++ b/test/BaseStorage.test.js
@@ -50,18 +50,18 @@ describe('Storage Base', function () {
         it('returns a filename with the original name, a secured hash and extension', function () {
             const storage = new StorageBase();
             const hash = 'a1b2c3d4e5f6';
-            const stem = 'something';
+            const name = 'something';
             const ext = '.jpg';
 
-            assert.equal(storage.generateFileName({stem, hash, ext}), `${stem}-${hash}${ext}`);
+            assert.equal(storage.generateFileName({name, hash, ext}), `${name}-${hash}${ext}`);
         });
 
         it('returns a filename with the original name and a secured hash when used without an extension', function () {
             const storage = new StorageBase();
             const hash = 'a1b2c3d4e5f6';
-            const stem = 'something';
+            const name = 'something';
 
-            assert.equal(storage.generateFileName({stem, hash}), `${stem}-${hash}`);
+            assert.equal(storage.generateFileName({name, hash}), `${name}-${hash}`);
         });
 
         it('truncates the basename to be under MAX_FILENAME_BYTES', function () {
@@ -69,10 +69,11 @@ describe('Storage Base', function () {
             const hash = 'a1b2c3d4e5f6';
             const ext = '.jpg';
             const lengthToRemove = '-'.length + hash.length + ext.length;
-            const stem = 'a'.repeat(MAX_FILENAME_BYTES);
-            const truncatedStem = 'a'.repeat(MAX_FILENAME_BYTES - lengthToRemove);
 
-            assert.equal(storage.generateFileName({stem, hash, ext}), `${truncatedStem}-${hash}${ext}`);
+            const name = 'a'.repeat(MAX_FILENAME_BYTES);
+            const truncatedName = 'a'.repeat(MAX_FILENAME_BYTES - lengthToRemove);
+
+            assert.equal(storage.generateFileName({name, hash, ext}), `${truncatedName}-${hash}${ext}`);
         });
 
         it('truncates a multi-bytes basename to be under MAX_FILENAME_BYTES', function () {
@@ -81,10 +82,10 @@ describe('Storage Base', function () {
             const ext = '.jpg';
             const lengthToRemove = '-'.length + hash.length + ext.length;
 
-            const stem = '🌴'.repeat(100); // 100 🌴 characters = 100 * 4 bytes = 400 bytes
-            const truncatedStem = '🌴'.repeat((MAX_FILENAME_BYTES - lengthToRemove) / 4);
+            const name = '🌴'.repeat(100); // 100 🌴 characters = 100 * 4 bytes = 400 bytes
+            const truncatedName = '🌴'.repeat((MAX_FILENAME_BYTES - lengthToRemove) / 4);
 
-            assert.equal(storage.generateFileName({stem, hash, ext}), `${truncatedStem}-${hash}${ext}`);
+            assert.equal(storage.generateFileName({name, hash, ext}), `${truncatedName}-${hash}${ext}`);
         });
     });
 

--- a/test/BaseStorage.test.js
+++ b/test/BaseStorage.test.js
@@ -8,12 +8,12 @@ describe('Storage Base', function () {
     describe('sanitizeFileName', function () {
         it('replaces non-ascii characters by -- in filenames', function () {
             const storage = new StorageBase();
-            storage.sanitizeFileName('(abc*@#123).zip').should.eql('-abc-@-123-.zip');
+            assert.equal(storage.sanitizeFileName('(abc*@#123).zip'), '-abc-@-123-.zip');
         });
 
         it('leaves ascii characters as is', function () {
             const storage = new StorageBase();
-            storage.sanitizeFileName('abc123.zip').should.eql('abc123.zip');
+            assert.equal(storage.sanitizeFileName('abc123.zip'), 'abc123.zip');
         });
     });
 
@@ -129,56 +129,56 @@ describe('Storage Base', function () {
     describe('getUniqueSecureFilePath', function () {
         it('accepts a file with non-ascii characters', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: '(abc*@#123).zip'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: '(abc*@#123).zip'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/-abc-@-123--\w{16}\.zip/);
         });
 
         it('accepts a file with a jpg extension', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'something.jpg'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'something.jpg'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/something-\w{16}\.jpg/);
         });
 
         it('accepts a file with a png extension', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'something.png'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'something.png'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/something-\w{16}\.png/);
         });
 
         it('accepts a file with a mp4 extension', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'something.mp4'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'something.mp4'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/something-\w{16}\.mp4/);
         });
 
         it('accepts a file without extension', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'something'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'something'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/something-\w{16}/);
         });
 
         it('accepts a file with an invalid extension .1', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'something.1'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'something.1'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/something.1-\w{16}/);
         });
 
         it('accepts a file with the original suffix', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'image_o.png', suffix: '_o'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'image_o.png', suffix: '_o'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/image-\w{16}_o\.png/);
         });
 
         it('accepts a file with the original suffix, if the suffix is not provided as parameter (default)', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: 'image_o.png'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: 'image_o.png'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/image-\w{16}_o\.png/);
         });
@@ -188,7 +188,7 @@ describe('Storage Base', function () {
 
             const filePaths = [];
             for (let i = 0; i < 10; i++) {
-                filePaths.push(storage.getUniqueSecureFilePath({file: {name: 'image.png'}, targetDir: 'target-dir'}));
+                filePaths.push(storage.getUniqueSecureFilePath({name: 'image.png'}, 'target-dir'));
             }
 
             assert.equal(filePaths.length, 10);
@@ -197,7 +197,7 @@ describe('Storage Base', function () {
 
         it('truncates an ascii filename to be under MAX_FILENAME_BYTES', function () {
             const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({file: {name: `a`.repeat(260) + '.png'}, targetDir: 'target-dir'});
+            const filePath = storage.getUniqueSecureFilePath({name: `a`.repeat(260) + '.png'}, 'target-dir');
             const fileName = path.basename(filePath);
 
             assert.equal(fileName.length, MAX_FILENAME_BYTES);

--- a/test/BaseStorage.test.js
+++ b/test/BaseStorage.test.js
@@ -1,91 +1,120 @@
-const should = require('should'),
-    Promise = require('bluebird'),
-    StorageBase = require('../BaseStorage');
+const should = require('should');
+const Promise = require('bluebird');
+const StorageBase = require('../BaseStorage');
+const assert = require('assert').strict;
+
+const MAX_FILENAME_BYTES = 255;
 
 describe('Storage Base', function () {
-    it('getSanitizedFileName: escape non accepted characters in filenames', function () {
-        const storage = new StorageBase();
-        storage.getSanitizedFileName('(abc*@#123).zip').should.eql('-abc-@-123-.zip');
+    describe('sanitizeBasename', function () {
+        it('sanitizeBasename: escape non accepted characters in filenames', function () {
+            const storage = new StorageBase();
+            storage.sanitizeBasename('(abc*@#123).zip').should.eql('-abc-@-123-.zip');
+        });
     });
 
-    it('getUniqueFileName: accepts jpg', function (done) {
-        const storage = new StorageBase();
-        let i = 0;
+    describe('getUniquePathname', function () {
+        it('accepts jpg', function () {
+            const storage = new StorageBase();
+            const pathname = storage.getUniquePathname({file: {name: 'something.jpg'}, targetDir: 'target-dir'});
 
-        storage.exists = function () {
-            i = i + 1;
+            assert.match(pathname, /target-dir\/something-\w{16}\.jpg/);
+        });
 
-            if (i < 2) {
-                return Promise.resolve(true);
-            } else {
-                return Promise.resolve(false);
-            }
-        };
+        it('accepts png', function () {
+            const storage = new StorageBase();
+            const pathname = storage.getUniquePathname({file: {name: 'something.png'}, targetDir: 'target-dir'});
 
-        storage.getUniqueFileName({name: 'something.jpg'}, 'target-dir')
-            .then(function (filename) {
-                filename.should.eql('target-dir/something-1.jpg');
-                done();
-            })
-            .catch(done);
+            assert.match(pathname, /target-dir\/something-\w{16}\.png/);
+        });
+
+        it('accepts mp4', function () {
+            const storage = new StorageBase();
+            const pathname = storage.getUniquePathname({file: {name: 'something.mp4'}, targetDir: 'target-dir'});
+
+            assert.match(pathname, /target-dir\/something-\w{16}\.mp4/);
+        });
+
+        it('ignores invalid extension .1', function () {
+            const storage = new StorageBase();
+            const pathname = storage.getUniquePathname({file: {name: 'something.1'}, targetDir: 'target-dir'});
+
+            assert.match(pathname, /target-dir\/something.1-\w{16}/);
+        });
     });
 
-    it('getUniqueFileName: accepts png', function (done) {
-        const storage = new StorageBase();
+    describe('generateSecureHash', function () {
+        it('should return a 16 character hash', function () {
+            const storage = new StorageBase();
+            assert.equal(storage.generateSecureHash().length, 16);
+        });
 
-        storage.exists = function () {
-            return Promise.resolve(false);
-        };
-
-        storage.getUniqueFileName({name: 'something.png'}, 'target-dir')
-            .then(function (filename) {
-                filename.should.eql('target-dir/something.png');
-                done();
-            })
-            .catch(done);
+        it('should return a different hash for each call', function () {
+            const storage = new StorageBase();
+            assert.notEqual(storage.generateSecureHash(), storage.generateSecureHash());
+        });
     });
 
-    it('getUniqueFileName: accepts mp4', function (done) {
-        const storage = new StorageBase();
-        let i = 0;
+    describe('generateFilename', function () {
+        it('should return a filename with the original name, a secured hash, suffix and extension', function () {
+            const storage = new StorageBase();
+            const hash = 'a1b2c3d4e5f6';
+            const stem = 'something';
+            const suffix = '_o';
+            const ext = '.jpg';
 
-        storage.exists = function () {
-            i = i + 1;
+            assert.equal(storage.generateFilename({stem, hash, suffix, ext}), `${stem}-${hash}${suffix}${ext}`);
+        });
 
-            if (i < 2) {
-                return Promise.resolve(true);
-            } else {
-                return Promise.resolve(false);
-            }
-        };
+        it('should return a filename with the original name, a secured hash and suffix, when used without an extension', function () {
+            const storage = new StorageBase();
+            const hash = 'a1b2c3d4e5f6';
+            const stem = 'something';
+            const suffix = '_o';
 
-        storage.getUniqueFileName({name: 'something.mp4'}, 'target-dir')
-            .then(function (filename) {
-                filename.should.eql('target-dir/something-1.mp4');
-                done();
-            })
-            .catch(done);
-    });
+            assert.equal(storage.generateFilename({stem, hash, suffix}), `${stem}-${hash}${suffix}`);
+        });
 
-    it('getUniqueFileName: deny .1 extension', function (done) {
-        const storage = new StorageBase();
-        let i = 0;
+        it('should return a filename with the original name, a secured hash and extension, when used without a suffix', function () {
+            const storage = new StorageBase();
+            const hash = 'a1b2c3d4e5f6';
+            const stem = 'something';
+            const ext = '.jpg';
 
-        storage.exists = function () {
-            i = i + 1;
+            assert.equal(storage.generateFilename({stem, hash, ext}), `${stem}-${hash}${ext}`);
+        });
 
-            if (i < 2) {
-                return Promise.resolve(true);
-            } else {
-                return Promise.resolve(false);
-            }
-        };
+        it('should return a filename with the original name and a secured hash, when used without a suffix and extension', function () {
+            const storage = new StorageBase();
+            const hash = 'a1b2c3d4e5f6';
+            const stem = 'something';
 
-        storage.getUniqueFileName({name: 'something.1'}, 'target-dir')
-            .then(function (filename) {
-                filename.should.eql('target-dir/something.1-1');
-                done();
-            })
-            .catch(done);
+            assert.equal(storage.generateFilename({stem, hash}), `${stem}-${hash}`);
+        });
+
+        it('should truncate the basename to be under MAX_FILENAME_BYTES', function () {
+            const storage = new StorageBase();
+            const hash = 'a1b2c3d4e5f6';
+            const suffix = '_o';
+            const ext = '.jpg';
+            const lengthToRemove = '-'.length + hash.length + suffix.length + ext.length;
+            const stem = 'a'.repeat(MAX_FILENAME_BYTES);
+            const truncatedStem = 'a'.repeat(MAX_FILENAME_BYTES - lengthToRemove);
+
+            assert.equal(storage.generateFilename({stem, hash, suffix, ext}), `${truncatedStem}-${hash}${suffix}${ext}`);
+        });
+
+        it('should truncate a multi-bytes basename to be under MAX_FILENAME_BYTES', function () {
+            const storage = new StorageBase();
+            const hash = 'a1b2c3d4e5f6';
+            const suffix = '_o';
+            const ext = '.jpg';
+            const lengthToRemove = '-'.length + hash.length + suffix.length + ext.length;
+
+            const stem = '🌴'.repeat(100); // 100 🌴 characters = 100 * 4 bytes = 400 bytes
+            const truncatedStem = '🌴'.repeat((MAX_FILENAME_BYTES - lengthToRemove) / 4);
+
+            assert.equal(storage.generateFilename({stem, hash, suffix, ext}), `${truncatedStem}-${hash}${suffix}${ext}`);
+        });
     });
 });

--- a/test/BaseStorage.test.js
+++ b/test/BaseStorage.test.js
@@ -2,7 +2,7 @@ const assert = require('assert').strict;
 const path = require('path');
 
 const StorageBase = require('../BaseStorage');
-const MAX_FILENAME_BYTES = 255;
+const MAX_FILENAME_BYTES = 253;
 
 describe('Storage Base', function () {
     describe('sanitizeFileName', function () {
@@ -34,23 +34,6 @@ describe('Storage Base', function () {
         });
     });
 
-    describe('getSuffix', function () {
-        it('returns the suffix of the file with an extension', function () {
-            const storage = new StorageBase();
-            assert.equal(storage.getSuffix({fileName: 'abc123_o.zip', ext: '.zip', suffix: '_o'}), '_o');
-        });
-
-        it('returns the suffix of the file without an extension', function () {
-            const storage = new StorageBase();
-            assert.equal(storage.getSuffix({fileName: 'abc123_o', suffix: '_o'}), '_o');
-        });
-
-        it('returns an empty string if the suffix is not at the end of the filename', function () {
-            const storage = new StorageBase();
-            assert.equal(storage.getSuffix({fileName: 'abc_o_123.zip', ext: '.zip', suffix: '_o'}), '');
-        });
-    });
-
     describe('generateSecureHash', function () {
         it('returns a 16 character hash', function () {
             const storage = new StorageBase();
@@ -64,26 +47,7 @@ describe('Storage Base', function () {
     });
 
     describe('generateFilename', function () {
-        it('returns a filename with the original name, a secured hash, suffix and extension', function () {
-            const storage = new StorageBase();
-            const hash = 'a1b2c3d4e5f6';
-            const stem = 'something';
-            const suffix = '_o';
-            const ext = '.jpg';
-
-            assert.equal(storage.generateFileName({stem, hash, suffix, ext}), `${stem}-${hash}${suffix}${ext}`);
-        });
-
-        it('returns a filename with the original name, a secured hash and suffix, when used without an extension', function () {
-            const storage = new StorageBase();
-            const hash = 'a1b2c3d4e5f6';
-            const stem = 'something';
-            const suffix = '_o';
-
-            assert.equal(storage.generateFileName({stem, hash, suffix}), `${stem}-${hash}${suffix}`);
-        });
-
-        it('returns a filename with the original name, a secured hash and extension, when used without a suffix', function () {
+        it('returns a filename with the original name, a secured hash and extension', function () {
             const storage = new StorageBase();
             const hash = 'a1b2c3d4e5f6';
             const stem = 'something';
@@ -92,7 +56,7 @@ describe('Storage Base', function () {
             assert.equal(storage.generateFileName({stem, hash, ext}), `${stem}-${hash}${ext}`);
         });
 
-        it('returns a filename with the original name and a secured hash, when used without a suffix and extension', function () {
+        it('returns a filename with the original name and a secured hash when used without an extension', function () {
             const storage = new StorageBase();
             const hash = 'a1b2c3d4e5f6';
             const stem = 'something';
@@ -103,26 +67,24 @@ describe('Storage Base', function () {
         it('truncates the basename to be under MAX_FILENAME_BYTES', function () {
             const storage = new StorageBase();
             const hash = 'a1b2c3d4e5f6';
-            const suffix = '_o';
             const ext = '.jpg';
-            const lengthToRemove = '-'.length + hash.length + suffix.length + ext.length;
+            const lengthToRemove = '-'.length + hash.length + ext.length;
             const stem = 'a'.repeat(MAX_FILENAME_BYTES);
             const truncatedStem = 'a'.repeat(MAX_FILENAME_BYTES - lengthToRemove);
 
-            assert.equal(storage.generateFileName({stem, hash, suffix, ext}), `${truncatedStem}-${hash}${suffix}${ext}`);
+            assert.equal(storage.generateFileName({stem, hash, ext}), `${truncatedStem}-${hash}${ext}`);
         });
 
         it('truncates a multi-bytes basename to be under MAX_FILENAME_BYTES', function () {
             const storage = new StorageBase();
             const hash = 'a1b2c3d4e5f6';
-            const suffix = '_o';
             const ext = '.jpg';
-            const lengthToRemove = '-'.length + hash.length + suffix.length + ext.length;
+            const lengthToRemove = '-'.length + hash.length + ext.length;
 
             const stem = '🌴'.repeat(100); // 100 🌴 characters = 100 * 4 bytes = 400 bytes
             const truncatedStem = '🌴'.repeat((MAX_FILENAME_BYTES - lengthToRemove) / 4);
 
-            assert.equal(storage.generateFileName({stem, hash, suffix, ext}), `${truncatedStem}-${hash}${suffix}${ext}`);
+            assert.equal(storage.generateFileName({stem, hash, ext}), `${truncatedStem}-${hash}${ext}`);
         });
     });
 
@@ -167,20 +129,6 @@ describe('Storage Base', function () {
             const filePath = storage.getUniqueSecureFilePath({name: 'something.1'}, 'target-dir');
 
             assert.match(filePath, /target-dir\/something.1-\w{16}/);
-        });
-
-        it('accepts a file with the original suffix', function () {
-            const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({name: 'image_o.png', suffix: '_o'}, 'target-dir');
-
-            assert.match(filePath, /target-dir\/image-\w{16}_o\.png/);
-        });
-
-        it('accepts a file with the original suffix, if the suffix is not provided as parameter (default)', function () {
-            const storage = new StorageBase();
-            const filePath = storage.getUniqueSecureFilePath({name: 'image_o.png'}, 'target-dir');
-
-            assert.match(filePath, /target-dir\/image-\w{16}_o\.png/);
         });
 
         it('does not generate the same filename when called 10 times with the same file', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1260
ref https://linear.app/ghost/issue/ENG-1859

- filenames are now generated using a 16-character hash, that gets re-generated on every upload
- we do not check whether the file exists anymore, as the chance of a collision is near zero below a million files in a directory
- if the filename length is higher than what most filesystem accept (255 bytes), we truncate the base of the filename, while keeping space for the unique hash and the file extension. Example to illustrate (non-accurate):
    - input: `long-name-for-an-image-imagine-255bytes-here-blablablablabla-and-a-bit-more.png`
    - output: `long-name-for-an-image-1a2b3c4d5e6f7g890.png`