### PR TITLE
Added Node 24 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,6 @@ jobs:
   test:
     uses: tryghost/actions/.github/workflows/test.yml@main
     with:
-      node-versions: '[22]'
+      node-versions: '[22, 24]'
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Run a single test: `yarn vitest run -t "<test name substring>"` (e.g. `yarn vitest run -t "generateUnique"`).
 - `yarn ship` — runs tests, then `yarn publish` and `git push --follow-tags`. Only succeeds with a clean working tree. Do not invoke unless the user explicitly asks to publish.
 
-Node 22 is required (`engines.node: ^22.13.1`). CI runs on Node 22 only via `tryghost/actions/.github/workflows/test.yml`.
+Node 22 or 24 is required (`engines.node: ^22.13.1 || ^24.0.0`). CI runs on Node 22 and 24 via `tryghost/actions/.github/workflows/test.yml`.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "moment": "2.29.4"
   },
   "engines": {
-    "node": "^22.13.1"
+    "node": "^22.13.1 || ^24.0.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.1.8",


### PR DESCRIPTION
## Summary

- Widen `engines.node` to `^22.13.1 || ^24.0.0` so the package installs on Node 24 without `--ignore-engines`.
- Extend the CI matrix to run tests on both Node 22 and Node 24.
- Update `AGENTS.md` (and the `CLAUDE.md` symlink to it) to reflect the new supported versions.

## Test plan

- [x] `yarn test` passes locally on Node 22 with 100% coverage maintained.
- [ ] CI runs the suite on both Node 22 and Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)