### PR TITLE
Removed .npmignore and added files allowlist to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.git*
-.idea
-node_modules/**
-test

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "license": "MIT",
   "main": "./lib/BaseStorage",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "moment": "2.30.1"
   },


### PR DESCRIPTION
`yarn ship` / `yarn publish` was creating an unnecessarily big tarball, by including `test/` and `coverage/` folders and e.g. `AGENTS.md` / `CLAUDE.md` files. Now, it contains only the minimum:

```
package/LICENSE
package/README.md
package/package.json
package/lib/BaseStorage.js
```

(`LICENSE`, `README.md`, and `package.json` are always included by npm/yarn automatically.)