### PR TITLE
Added oxlint linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,26 @@ on:
       - main
       - 'renovate/*'
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    env:
+      FORCE_COLOR: 1
+    name: Lint
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: 22
+          cache: yarn
+
+      - run: yarn --prefer-offline --frozen-lockfile
+      - run: yarn lint
+
   test:
     uses: tryghost/actions/.github/workflows/test.yml@9b2a4a48cd458728c438c7fc090b3863b494cd16 # main
     with:

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "off",
+    "suspicious": "off",
+    "style": "off",
+    "pedantic": "off",
+    "perf": "off",
+    "restriction": "off",
+    "nursery": "off"
+  },
+  "plugins": ["import", "vitest"],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/coverage/**",
+    "**/dist/**",
+    "**/build/**"
+  ],
+  "rules": {
+    "eqeqeq": "error",
+    "no-console": "off",
+    "no-unused-vars": "error",
+    "prefer-const": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost-Storage-Base/issues",
   "scripts": {
+    "lint": "oxlint .",
+    "lint:fix": "oxlint --fix .",
     "test": "yarn test:unit",
     "test:unit": "vitest run --coverage",
     "preship": "yarn test",
@@ -33,6 +35,7 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.1.8",
+    "oxlint": "1.56.0",
     "vite": "8.0.16",
     "vitest": "4.1.8"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,101 @@
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.133.0.tgz#2e282ef9e1d26e06b68ccd14b73f310a3b2cf7f8"
   integrity sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==
 
+"@oxlint/binding-android-arm-eabi@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.56.0.tgz#c62ca8fb50d8134cfcd107d98ff5c43cadbebd81"
+  integrity sha512-IyfYPthZyiSKwAv/dLjeO18SaK8MxLI9Yss2JrRDyweQAkuL3LhEy7pwIwI7uA3KQc1Vdn20kdmj3q0oUIQL6A==
+
+"@oxlint/binding-android-arm64@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-android-arm64/-/binding-android-arm64-1.56.0.tgz#685525cd82ecd1106913da63454b3d263550432b"
+  integrity sha512-Ga5zYrzH6vc/VFxhn6MmyUnYEfy9vRpwTIks99mY3j6Nz30yYpIkWryI0QKPCgvGUtDSXVLEaMum5nA+WrNOSg==
+
+"@oxlint/binding-darwin-arm64@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.56.0.tgz#4794c4775840137d26401f86476dbc5b56d3f23e"
+  integrity sha512-ogmbdJysnw/D4bDcpf1sPLpFThZ48lYp4aKYm10Z/6Nh1SON6NtnNhTNOlhEY296tDFItsZUz+2tgcSYqh8Eyw==
+
+"@oxlint/binding-darwin-x64@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.56.0.tgz#5e1be617a6a23d1f5973d2d12c4e004a77cd7085"
+  integrity sha512-x8QE1h+RAtQ2g+3KPsP6Fk/tdz6zJQUv5c7fTrJxXV3GHOo+Ry5p/PsogU4U+iUZg0rj6hS+E4xi+mnwwlDCWQ==
+
+"@oxlint/binding-freebsd-x64@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.56.0.tgz#04502145f8e7f2ee84c8ea200ed0a59f3a298f0a"
+  integrity sha512-6G+WMZvwJpMvY7my+/SHEjb7BTk/PFbePqLpmVmUJRIsJMy/UlyYqjpuh0RCgYYkPLcnXm1rUM04kbTk8yS1Yg==
+
+"@oxlint/binding-linux-arm-gnueabihf@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.56.0.tgz#c97cc9ee8e725483bf9dee078ef008d637159178"
+  integrity sha512-YYHBsk/sl7fYwQOok+6W5lBPeUEvisznV/HZD2IfZmF3Bns6cPC3Z0vCtSEOaAWTjYWN3jVsdu55jMxKlsdlhg==
+
+"@oxlint/binding-linux-arm-musleabihf@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.56.0.tgz#ed2d5a200eab3825f4bb7cf1a1c33c3f63722397"
+  integrity sha512-+AZK8rOUr78y8WT6XkDb04IbMRqauNV+vgT6f8ZLOH8wnpQ9i7Nol0XLxAu+Cq7Sb+J9wC0j6Km5hG8rj47/yQ==
+
+"@oxlint/binding-linux-arm64-gnu@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.56.0.tgz#e195667892d7fd104582fcaaf7c687aeef77e7d8"
+  integrity sha512-urse2SnugwJRojUkGSSeH2LPMaje5Q50yQtvtL9HFckiyeqXzoFwOAZqD5TR29R2lq7UHidfFDM9EGcchcbb8A==
+
+"@oxlint/binding-linux-arm64-musl@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.56.0.tgz#2e0abc6e034d0d6669715075173fa3bae79ec08e"
+  integrity sha512-rkTZkBfJ4TYLjansjSzL6mgZOdN5IvUnSq3oNJSLwBcNvy3dlgQtpHPrRxrCEbbcp7oQ6If0tkNaqfOsphYZ9g==
+
+"@oxlint/binding-linux-ppc64-gnu@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.56.0.tgz#e681dcf14e1ce99c6a440a64c3a3ba9d1415ffb6"
+  integrity sha512-uqL1kMH3u69/e1CH2EJhP3CP28jw2ExLsku4o8RVAZ7fySo9zOyI2fy9pVlTAp4voBLVgzndXi3SgtdyCTa2aA==
+
+"@oxlint/binding-linux-riscv64-gnu@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.56.0.tgz#ac1f7ebd85abc913474f4428eb6bb568f0d2b8ea"
+  integrity sha512-j0CcMBOgV6KsRaBdsebIeiy7hCjEvq2KdEsiULf2LZqAq0v1M1lWjelhCV57LxsqaIGChXFuFJ0RiFrSRHPhSg==
+
+"@oxlint/binding-linux-riscv64-musl@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.56.0.tgz#92a2c407404b13647eaec274ce59eca389df24d1"
+  integrity sha512-7VDOiL8cDG3DQ/CY3yKjbV1c4YPvc4vH8qW09Vv+5ukq3l/Kcyr6XGCd5NvxUmxqDb2vjMpM+eW/4JrEEsUetA==
+
+"@oxlint/binding-linux-s390x-gnu@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.56.0.tgz#bf38537cff65fca07c4fc5ce665ea17099cb8601"
+  integrity sha512-JGRpX0M+ikD3WpwJ7vKcHKV6Kg0dT52BW2Eu2BupXotYeqGXBrbY+QPkAyKO6MNgKozyTNaRh3r7g+VWgyAQYQ==
+
+"@oxlint/binding-linux-x64-gnu@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.56.0.tgz#14f3978d59e132e8b32036eb088a5a450a37a904"
+  integrity sha512-dNaICPvtmuxFP/VbqdofrLqdS3bM/AKJN3LMJD52si44ea7Be1cBk6NpfIahaysG9Uo+L98QKddU9CD5L8UHnQ==
+
+"@oxlint/binding-linux-x64-musl@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.56.0.tgz#a601f23531cff6057dc4a9eb8c96cc2b6100f26d"
+  integrity sha512-pF1vOtM+GuXmbklM1hV8WMsn6tCNPvkUzklj/Ej98JhlanbmA2RB1BILgOpwSuCTRTIYx2MXssmEyQQ90QF5aA==
+
+"@oxlint/binding-openharmony-arm64@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.56.0.tgz#1be4f2186ab23695f274173881ef7f1c25c1165b"
+  integrity sha512-bp8NQ4RE6fDIFLa4bdBiOA+TAvkNkg+rslR+AvvjlLTYXLy9/uKAYLQudaQouWihLD/hgkrXIKKzXi5IXOewwg==
+
+"@oxlint/binding-win32-arm64-msvc@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.56.0.tgz#f0fe81f7ceba13b846a9470d8004ad5c45999642"
+  integrity sha512-PxT4OJDfMOQBzo3OlzFb9gkoSD+n8qSBxyVq2wQSZIHFQYGEqIRTo9M0ZStvZm5fdhMqaVYpOnJvH2hUMEDk/g==
+
+"@oxlint/binding-win32-ia32-msvc@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.56.0.tgz#ee097fa11e7bacdbb3f925f8aca14ed1fce8a51e"
+  integrity sha512-PTRy6sIEPqy2x8PTP1baBNReN/BNEFmde0L+mYeHmjXE1Vlcc9+I5nsqENsB2yAm5wLkzPoTNCMY/7AnabT4/A==
+
+"@oxlint/binding-win32-x64-msvc@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.56.0.tgz#68cc0cd4bc9da1ccff9164ef1779bbcde369cb4d"
+  integrity sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ==
+
 "@rolldown/binding-android-arm64@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz#54ce8f8382213f4a314a0c2f7ba83f81ffeae592"
@@ -478,6 +573,31 @@ obug@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.3.tgz#c02c60f95abd603409330e767db7f2823193331e"
   integrity sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==
+
+oxlint@1.56.0:
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/oxlint/-/oxlint-1.56.0.tgz#b538b0171c5560212ffd38b479aca9efa6b8dafc"
+  integrity sha512-Q+5Mj5PVaH/R6/fhMMFzw4dT+KPB+kQW4kaL8FOIq7tfhlnEVp6+3lcWqFruuTNlUo9srZUW3qH7Id4pskeR6g==
+  optionalDependencies:
+    "@oxlint/binding-android-arm-eabi" "1.56.0"
+    "@oxlint/binding-android-arm64" "1.56.0"
+    "@oxlint/binding-darwin-arm64" "1.56.0"
+    "@oxlint/binding-darwin-x64" "1.56.0"
+    "@oxlint/binding-freebsd-x64" "1.56.0"
+    "@oxlint/binding-linux-arm-gnueabihf" "1.56.0"
+    "@oxlint/binding-linux-arm-musleabihf" "1.56.0"
+    "@oxlint/binding-linux-arm64-gnu" "1.56.0"
+    "@oxlint/binding-linux-arm64-musl" "1.56.0"
+    "@oxlint/binding-linux-ppc64-gnu" "1.56.0"
+    "@oxlint/binding-linux-riscv64-gnu" "1.56.0"
+    "@oxlint/binding-linux-riscv64-musl" "1.56.0"
+    "@oxlint/binding-linux-s390x-gnu" "1.56.0"
+    "@oxlint/binding-linux-x64-gnu" "1.56.0"
+    "@oxlint/binding-linux-x64-musl" "1.56.0"
+    "@oxlint/binding-openharmony-arm64" "1.56.0"
+    "@oxlint/binding-win32-arm64-msvc" "1.56.0"
+    "@oxlint/binding-win32-ia32-msvc" "1.56.0"
+    "@oxlint/binding-win32-x64-msvc" "1.56.0"
 
 pathe@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
## Summary
- add Oxlint as the repository linter with an explicit `.oxlintrc.json` adapted from TryGhost/Toast#882
- add `yarn lint` and `yarn lint:fix` scripts plus the locked `oxlint@1.56.0` dependency
- add a dedicated CI lint job alongside the existing reusable test workflow

## Testing
- `yarn lint`
- `yarn test`