### PR TITLE
Fixed Renovate required check handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
   all-tests-pass:
     name: All tests pass
-    if: always()
+    if: always() && (github.event_name == 'push' || !startsWith(github.head_ref, 'renovate/'))
     needs: [lint, build]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What changed

Updated the `All tests pass` aggregate job so it does not run on `pull_request` events from `renovate/*` branches.

## Why

Renovate branches already run the `Test` workflow on `push`, and that run produces the real `All tests pass` required check. The matching `pull_request` run intentionally skips `lint` and `build`, which made the aggregate job fail after skipped dependencies were treated as fatal. That created a duplicate failing `All tests pass` check and blocked Renovate PRs such as #102 even though the push CI had passed.

The gate remains strict for normal PRs and push runs: failed, cancelled, or unexpectedly skipped dependencies still fail `All tests pass`.

## Validation

- Parsed `.github/workflows/test.yml` as YAML
- Ran `git diff --check`
- Ran `CI=true pnpm lint`