### PR TITLE
Run required checks for Renovate PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     env:
       FORCE_COLOR: 1
     name: Lint
@@ -31,7 +30,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed

Removed the Renovate-specific job-level skips from the `lint` and `build` jobs in the `Test` workflow.

## Why

The repository ruleset requires the stable `All tests pass` aggregate check. Renovate PRs should satisfy that gate the same way every other PR does: by running lint and the Node test matrix, then letting the aggregate job pass only if those dependencies succeeded.

The previous workflow skipped `lint` and `build` on `pull_request` events from `renovate/*`, which meant the aggregate job could only either pass without real PR CI or fail because its dependencies were skipped. Removing the skips makes Renovate PR checks real and keeps the aggregate gate strict.

## Validation

- Parsed `.github/workflows/test.yml` as YAML
- Ran `git diff --check`
- Ran `CI=true pnpm lint`