### PR TITLE
Fixed Express types dependency scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "dist"
   ],
   "dependencies": {
-    "@types/express": "5.0.6",
     "moment": "2.30.1"
   },
   "engines": {
     "node": "^22.13.1 || ^24.0.0"
   },
   "devDependencies": {
+    "@types/express": "5.0.6",
     "@types/node": "24.13.2",
     "@vitest/coverage-v8": "4.1.9",
     "oxlint": "1.70.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
-      '@types/express':
-        specifier: 5.0.6
-        version: 5.0.6
       moment:
         specifier: 2.30.1
         version: 2.30.1
     devDependencies:
+      '@types/express':
+        specifier: 5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2


### PR DESCRIPTION
## Summary

- moved `@types/express` from runtime `dependencies` to `devDependencies`
- updated the pnpm lockfile importer metadata to match

## Why

`ghost-storage-base` only uses Express for TypeScript declarations. Shipping `@types/express@5` as a runtime dependency installs Express 5 declarations into downstream consumers even when they run Express 4 or provide their own Express type version. Keeping the type package as a dev dependency preserves this package's own build while avoiding the transitive type leak.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test`