### PR TITLE
Added OIDC trusted publishing to npm via CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview what would be published without actually publishing'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    permissions:
+      # OIDC trusted publishing to npm. Provenance is enabled because this
+      # repository is public; public repos can generate a provenance
+      # attestation at publish time.
+      id-token: write
+      contents: read
+
+    env:
+      FORCE_COLOR: 1
+      CI: true
+      NPM_CONFIG_PROVENANCE: true
+      NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24.14.1'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Corepack
+        run: npm install --global corepack@0.34.6
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Determine whether to publish
+        id: pub
+        run: |
+          name=$(jq -r .name package.json)
+          version=$(jq -r .version package.json)
+          if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+            echo "$name@$version is already published; nothing to do"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "queueing $name@$version"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.pub.outputs.publish == 'true'
+        # --no-git-checks is required because actions/checkout leaves the repo on
+        # a detached HEAD, which pnpm's default publish branch check rejects.
+        run: pnpm publish --no-git-checks ${{ (github.event.inputs['dry-run'] == 'true' && '--dry-run') || '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repo is the TypeScript 5 `ghost-storage-base` npm package for Ghost storage
 - `pnpm test` — run the Vitest suite with coverage (this is the only test command; `pnpm test:unit` is the same thing). Vitest runs against the TS source directly; you do not need to `pnpm build` first.
 - `pnpm lint` — run oxlint.
 - Run a single test: `pnpm vitest run -t "<test name substring>"` (e.g. `pnpm vitest run -t "generateUnique"`).
-- `pnpm ship <patch|minor|major|version>` — runs tests, then delegates to `@tryghost/pro-ship` (`pro-ship --publish`) to bump the version, commit, tag, push, and publish. A release type or explicit version is required (for example `pnpm ship patch`). The build runs automatically via the `prepare` script (see below). Only succeeds with a clean working tree. Do not invoke unless the user explicitly asks to publish.
+- `pnpm ship <patch|minor|major|version>` — runs tests (via the `preship` script), then delegates to `@tryghost/pro-ship` (`pro-ship`) to bump the version, commit, tag, and push. A release type or explicit version is required (for example `pnpm ship patch`). The build runs automatically via the `prepare` script (see below). Only succeeds with a clean working tree. Do not invoke unless the user explicitly asks to release. **Publishing to npm no longer happens locally** — pushing the version-bump commit to `main` triggers `.github/workflows/publish.yml`, which publishes to npm via OIDC trusted publishing (no `NPM_TOKEN`; `id-token: write` + provenance). The workflow only publishes when `package.json`'s `name@version` is not already on the registry, so re-runs are safe.
 
 ### Build lifecycle
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "vitest run --coverage",
     "test:unit": "pnpm test",
     "prepare": "npm run build",
-    "ship": "sh -c 'if [ \"$#\" -eq 0 ]; then echo \"Usage: pnpm ship <patch|minor|major|version>\"; exit 1; fi; pnpm test && pro-ship --publish \"$@\"' --"
+    "preship": "pnpm test",
+    "ship": "pro-ship"
   },
   "license": "MIT",
   "main": "./dist/BaseStorage.js",


### PR DESCRIPTION
- Moves the npm publish out of `pnpm ship` and into a new `.github/workflows/publish.yml` that runs on version bumps to main
- Publishes via OIDC (id-token + provenance) instead of a long-lived NPM_TOKEN, matching the pattern used in knex-migrator
- `ship` is now `pro-ship` (bump/commit/tag/push only) with tests gated by the `preship` hook